### PR TITLE
Switch to use Action Provider Tools Blueprint

### DIFF
--- a/action_provider/main.py
+++ b/action_provider/main.py
@@ -208,6 +208,9 @@ def create_app() -> Flask:
         import_name=__name__,
         provider_description=provider_description,
     )
+    
+    # Contributor: Stephen Rosen
+    # https://github.com/haochenpan/diaspora-service/pull/42
     # register routes
     ap_blueprint.action_run(action_run)
     ap_blueprint.action_status(action_status)

--- a/action_provider/main.py
+++ b/action_provider/main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib.metadata as importlib_metadata
 import os
 
-from flask import Blueprint
 from flask import Flask
 from globus_action_provider_tools import ActionProviderDescription
 from globus_action_provider_tools import ActionRequest
@@ -18,7 +17,7 @@ from globus_action_provider_tools.authorization import (
 from globus_action_provider_tools.authorization import (
     authorize_action_management_or_404,
 )
-from globus_action_provider_tools.flask import add_action_routes_to_blueprint
+from globus_action_provider_tools.flask import ActionProviderBlueprint
 from globus_action_provider_tools.flask.exceptions import ActionConflict
 from globus_action_provider_tools.flask.helpers import assign_json_provider
 from globus_action_provider_tools.flask.types import ActionCallbackReturn
@@ -190,8 +189,6 @@ def create_app() -> Flask:
     assign_json_provider(app)
     app.url_map.strict_slashes = False
 
-    skeleton_blueprint = Blueprint('diaspora', __name__)
-
     provider_description = ActionProviderDescription(
         globus_auth_scope=CLIENT_SCOPE,
         title='Diaspora Action Provider',
@@ -204,18 +201,20 @@ def create_app() -> Flask:
         visible_to=['public'],
     )
 
-    add_action_routes_to_blueprint(
-        blueprint=skeleton_blueprint,
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
+    app.config.DIASPORA_CLIENT_ID = CLIENT_ID
+    app.config.DIASPORA_CLIENT_SECRET = CLIENT_SECRET
+    ap_blueprint = ActionProviderBlueprint(
+        name='diaspora',
+        import_name=__name__,
         provider_description=provider_description,
-        action_run_callback=action_run,
-        action_status_callback=action_status,
-        action_cancel_callback=action_cancel,
-        action_release_callback=action_release,
     )
+    # register routes
+    ap_blueprint.action_run(action_run)
+    ap_blueprint.action_status(action_status)
+    ap_blueprint.action_cancel(action_cancel)
+    ap_blueprint.action_release(action_release)
 
-    app.register_blueprint(skeleton_blueprint)
+    app.register_blueprint(ap_blueprint)
 
     return app
 


### PR DESCRIPTION
:wave: Hi, Globus developer here!

We have some changes the team has been working on to improve Action Provider Tools, in particular to improve the ways in which it interacts with the Globus Auth and Groups services.
As a result, we're removing `add_action_routes_to_blueprint` in favor of only supporting the `ActionProviderBlueprint` path -- this gives all of us (library maintainers and users) a handle on some specific object or abstraction which the library is providing, and will allow us to expose the coming changes more cleanly.
The latest release (0.19.1) still provides `add_action_routes_to_blueprint`, but it will be removed in the next one (probably v0.20.0).

I'm suggesting this change to try to help you update, but I wasn't able to run the testsuite in this repo, as it appears to require credentials.
Please let me know if there's more we can do to assist!

---

'add_action_routes_to_blueprint' is being removed in an upcoming release. The activities which it performed are better encapsulated by 'ActionProviderBlueprint', which is available in all recent versions of Action Provider Tools.

The blueprint provides registration methods which can be used as decorators, but to preserve the semantics of the current application as much as possible, I have refrained from using them as such.
The registration calls are made imperatively in the app factory, similar to how the `add_action_routes_to_blueprint` function behaved.

The ActionProviderBlueprint looks up client credentials from app config based on the name of the blueprint, so the client credential names are set appropriately in app config to match.
